### PR TITLE
Fix Circular Import Error by adding sub modules to installer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ docs = [
     "sphinxcontrib-mermaid" # for mermaid diagrams
 ]
 
-[tool.setuptools]
-packages = ["topotherm"]
+[tool.setuptools.packages.find]
+include = ["topotherm", "topotherm.*"]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.


### PR DESCRIPTION
After installing topotherm

```
cd topotherm
pip install .
```

I tried using the examples but it failed:

```
(.venv) C:\Users\xxx\Git\topotherm\examples\one-producer>python run_sts.py 

Traceback (most recent call last):
  File "C:\Users\xxx\Git\topotherm\examples\one-producer\run_sts.py", line 15, in <module>
    import topotherm as tt

  File "C:\Users\xxx\Git\topotherm\.venv\Lib\site-packages\topotherm\__init__.py", line 4, in <module>
    from . import models as models

ImportError: cannot import name 'models' from partially initialized module 'topotherm' (most likely due to a circular import) (C:\Users\xx`x\Git\topotherm\.venv\Lib\site-packages\topotherm\__init__.py)
```

When I copy the topotherm source folder to \examples\one-producer\ it works.

So I discovered that the problem is due missing \models\ folder and added it to the pyproject.toml.